### PR TITLE
Update index.html env instructions to Snowpack v3

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,11 +9,11 @@
       content="Web site created using create-snowpack-app"
     />
     <!--
-      Snowpack will replace %PUBLIC_URL% with the value you have for `homepage` in `package.json`.
+      Snowpack will replace %PUBLIC_URL% with the value you have for `baseUrl` in `snowpack.config.js`.
       Make sure to update it with your GitHub Page URL. https://<your-username>.github.io/<your-repo-name>
 
       More about config options:
-      - https://www.snowpack.dev/#config-files
+      - https://www.snowpack.dev/reference/configuration#buildoptions.baseurl
     -->
     <link
       rel="stylesheet"

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -4,4 +4,7 @@ module.exports = {
     public: '/',
     src: '/_dist_',
   },
+  buildOptions: {
+    baseUrl: '',
+  },
 }


### PR DESCRIPTION
Hi Jonathan!

According to the [Snowpack v2 -> v3 migration](https://www.snowpack.dev/guides/upgrade-guide#upgrading-from-snowpack-v2), the %PUBLIC_URL% isn't set from `homepage` in `package.json` anymore, but it is now read from `buildOptions.baseUrl` from `snowpack.config.js`.

This change adds the entry to the `snowpack.config.js` as an empty string (that's the default value, but I'm making it explicit) and changes a bit the comment found in the `index.html` file.

Nice work with the template, I'm using it to learn a bit of things about Snowpack :smile:.